### PR TITLE
Adding (SHIFT + ENTER) functionality to allow multiline text entry

### DIFF
--- a/program.py
+++ b/program.py
@@ -11,6 +11,8 @@ import time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
 
 # account credentials
 json_file = open("secret.json")
@@ -128,7 +130,11 @@ def completeForm(link):
     f[2].send_keys(variables["email"])
     f[3].send_keys(variables["phone_no"])
     t = driver.find_elements(By.XPATH, '//textarea')
-    t[0].send_keys(variables["pitch"])
+    for part in variables["extra"].split('\n'):
+        t[0].send_keys(part)
+        ActionChains(driver).key_down(Keys.SHIFT).key_down(Keys.ENTER).key_up(Keys.SHIFT).key_up(Keys.ENTER).perform()
+
+    # t[0].send_keys(variables["pitch"])
 
     time.sleep(5)
 


### PR DESCRIPTION
Using '\n' isn't enough for a textarea to go to a newline. 

SHIFT + ENTER needs to be used to go to a new line. 

Added functionality to use (SHIFT + ENTER) whenever the text has a '\n' character.

Reference used: https://stackoverflow.com/a/61211459
